### PR TITLE
Fix hwdata source tarball name

### DIFF
--- a/SPECS/hwdata/hwdata.signatures.json
+++ b/SPECS/hwdata/hwdata.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "v0.341.tar.gz": "6790f192861b85972105a113d43e12d58d5fbb796e908aa0d84c8f9e0fa4facc"
+  "hwdata-0.341.tar.gz": "6790f192861b85972105a113d43e12d58d5fbb796e908aa0d84c8f9e0fa4facc"
  }
 }

--- a/SPECS/hwdata/hwdata.spec
+++ b/SPECS/hwdata/hwdata.spec
@@ -1,12 +1,13 @@
 Summary:        Hardware identification and configuration data
 Name:           hwdata
 Version:        0.341
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2+ OR XFree86 1.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://github.com/vcrhonek/hwdata
-Source:         https://github.com/vcrhonek/hwdata/archive/v%{version}.tar.gz
+#Source0:         https://github.com/vcrhonek/hwdata/archive/v%{version}.tar.gz
+Source0:        %{name}-%{version}.tar.gz
 
 BuildArch:      noarch
 
@@ -31,6 +32,9 @@ make install DESTDIR=%{buildroot} libdir=%{_lib}
 %{_datadir}/%{name}/*
 
 %changelog
+* Mon Mar 29 2021 Andrew Phelps <anphel@microsoft.com> - 0.341-3
+- Fix source tarball name
+
 * Fri Dec 18 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.341-2
 - Initial CBL-Mariner import from Fedora 33 (license: MIT).
 - License verified.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*

- [ ] Any updated packages successfully build (or no packages were changed).
- [x] All package sources are available.
- [ ] The `%check` section passes for any new packages.
- [x] `./cgmanifest.json` is up-to-date and sorted
- [x] `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md` file is up-to-date and sorted.
- [x] All source files have up-to-date hashes in the `*.signatures.json` files.
- [ ] Ready to merge.

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?
hwdata package had a generic filename "v0.341.tar.gz" which is likely to cause collisions on the source server. Rename this file to "hwdata-0.341.tar.gz"

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change hwdata spec and signatures.json files

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local package build