### PR TITLE
Re-naming 'hwdata', 'vulkan-headers', and 'vulkan-loader' sources to avoid conflicts.

### DIFF
--- a/SPECS/gsm/gsm.spec
+++ b/SPECS/gsm/gsm.spec
@@ -10,7 +10,7 @@ License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            http://www.quut.com/gsm/
-Source:         http://www.quut.com/gsm/%{name}-%{version}.tar.gz
+Source0:        http://www.quut.com/gsm/%{name}-%{version}.tar.gz
 
 Patch0:         %{name}-makefile.patch
 Patch1:         %{name}-warnings.patch

--- a/SPECS/hwdata/hwdata.signatures.json
+++ b/SPECS/hwdata/hwdata.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "v0.341.tar.gz": "6790f192861b85972105a113d43e12d58d5fbb796e908aa0d84c8f9e0fa4facc"
+  "hwdata-0.341.tar.gz": "6790f192861b85972105a113d43e12d58d5fbb796e908aa0d84c8f9e0fa4facc"
  }
 }

--- a/SPECS/hwdata/hwdata.spec
+++ b/SPECS/hwdata/hwdata.spec
@@ -1,7 +1,7 @@
 Summary:        Hardware identification and configuration data
 Name:           hwdata
 Version:        0.341
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPLv2+ OR XFree86 1.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -33,6 +33,9 @@ make install DESTDIR=%{buildroot} libdir=%{_lib}
 %{_datadir}/%{name}/*
 
 %changelog
+* Mon Mar 29 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.341-3
+- Changed source tarball name.
+
 * Fri Dec 18 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.341-2
 - Initial CBL-Mariner import from Fedora 33 (license: MIT).
 - License verified.

--- a/SPECS/hwdata/hwdata.spec
+++ b/SPECS/hwdata/hwdata.spec
@@ -6,7 +6,7 @@ License:        GPLv2+ OR XFree86 1.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://github.com/vcrhonek/hwdata
-Source:         https://github.com/vcrhonek/hwdata/archive/v%{version}.tar.gz
+Source0:        https://github.com/vcrhonek/hwdata/archive/v%{version}.tar.gz
 
 BuildArch:      noarch
 

--- a/SPECS/hwdata/hwdata.spec
+++ b/SPECS/hwdata/hwdata.spec
@@ -6,7 +6,9 @@ License:        GPLv2+ OR XFree86 1.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://github.com/vcrhonek/hwdata
-Source0:        https://github.com/vcrhonek/hwdata/archive/v%{version}.tar.gz
+#WARNING: the source file downloads as 'v%%{version}.tar.gz' and MUST be re-named to match the 'Source0' tag.
+#Source0:       %%{url}/archive/v%%{version}.tar.gz
+Source0:        %{name}-%{version}.tar.gz
 
 BuildArch:      noarch
 

--- a/SPECS/vulkan-headers/vulkan-headers.signatures.json
+++ b/SPECS/vulkan-headers/vulkan-headers.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "sdk-1.2.148.0.tar.gz": "0803784b701c461ff5cce30bb8c598db5780032cf780c954d676e142bc3c373f"
+  "vulkan-headers-1.2.148.0.tar.gz": "0803784b701c461ff5cce30bb8c598db5780032cf780c954d676e142bc3c373f"
  }
 }

--- a/SPECS/vulkan-headers/vulkan-headers.spec
+++ b/SPECS/vulkan-headers/vulkan-headers.spec
@@ -6,7 +6,9 @@ License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://github.com/KhronosGroup/Vulkan-Headers
-Source0:        %{url}/archive/sdk-%{version}.tar.gz
+#WARNING: the source file downloads as 'sdk-%%{version}.tar.gz' and MUST be re-named to match the 'Source0' tag.
+#Source0:       %%{url}/archive/sdk-%%{version}.tar.gz
+Source0:        %{name}-%{version}.tar.gz
 
 BuildArch:      noarch
 

--- a/SPECS/vulkan-headers/vulkan-headers.spec
+++ b/SPECS/vulkan-headers/vulkan-headers.spec
@@ -1,7 +1,7 @@
 Summary:        Vulkan Header files and API registry
 Name:           vulkan-headers
 Version:        1.2.148.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -38,6 +38,9 @@ Vulkan Header files and API registry
 %{_datadir}/vulkan/registry/
 
 %changelog
+* Mon Mar 29 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.2.148.0-3
+- Changed source tarball name.
+
 * Fri Jan 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.2.148.0-2
 - Initial CBL-Mariner import from Fedora 33 (license: MIT).
 - License verified.

--- a/SPECS/vulkan-loader/vulkan-loader.signatures.json
+++ b/SPECS/vulkan-loader/vulkan-loader.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "sdk-1.2.148.1.tar.gz": "f36555d29e518a4da104e5cdfb9cc6778637fbfad407608389cb424abe61aa2b"
+  "vulkan-loader-1.2.148.1.tar.gz": "f36555d29e518a4da104e5cdfb9cc6778637fbfad407608389cb424abe61aa2b"
  }
 }

--- a/SPECS/vulkan-loader/vulkan-loader.spec
+++ b/SPECS/vulkan-loader/vulkan-loader.spec
@@ -6,7 +6,9 @@ License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://github.com/KhronosGroup/Vulkan-Loader
-Source0:        %{url}/archive/sdk-%{version}.tar.gz
+#WARNING: the source file downloads as 'sdk-%%{version}.tar.gz' and MUST be re-named to match the 'Source0' tag.
+#Source0:       %%{url}/archive/sdk-%%{version}.tar.gz
+Source0:        %{name}-%{version}.tar.gz
 
 BuildRequires:  cmake
 BuildRequires:  gcc

--- a/SPECS/vulkan-loader/vulkan-loader.spec
+++ b/SPECS/vulkan-loader/vulkan-loader.spec
@@ -1,7 +1,7 @@
 Summary:        Vulkan ICD desktop loader
 Name:           vulkan-loader
 Version:        1.2.148.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        ASL 2.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -87,6 +87,9 @@ mkdir -p %{buildroot}%{_sysconfdir}/vulkan/{explicit,implicit}_layer.d/ \
 %{_libdir}/*.so
 
 %changelog
+* Mon Mar 29 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.2.148.1-3
+- Changed source tarball name.
+
 * Fri Jan 15 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.2.148.1-2
 - Initial CBL-Mariner import from Fedora 33 (license: MIT).
 - License verified.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*

- [x] Any updated packages successfully build (or no packages were changed).
- [x] All package sources are available.
- [x] The `%check` section passes for any new packages.
- [x] `./cgmanifest.json` is up-to-date and sorted
- [x] `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md` file is up-to-date and sorted.
- [x] All source files have up-to-date hashes in the `*.signatures.json` files.
- [x] Ready to merge.

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

The default names for the downloaded source tarballs for the modified packages were too conflict-prone and didn't contain the package names in them, so we're switching them to the more common `%{name}-%{version}.tar.gz` format.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Updated source tarball name for `hwdata`.
- Updated source tarball name for `vulkan-headers`.
- Updated source tarball name for `vulkan-loader`.
- Unified the use of `Source0` in the specs.

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build packages build.
