### PR TITLE
Fix %{_lib} macro usage in hwdata

### DIFF
--- a/SPECS/hwdata/hwdata.spec
+++ b/SPECS/hwdata/hwdata.spec
@@ -1,7 +1,7 @@
 Summary:        Hardware identification and configuration data
 Name:           hwdata
 Version:        0.341
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        GPLv2+ OR XFree86 1.0
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -24,15 +24,18 @@ such as the pci.ids and usb.ids databases.
 # nothing to build
 
 %install
-make install DESTDIR=%{buildroot} libdir=%{_lib}
+make install DESTDIR=%{buildroot} libdir=%{_libdir}
 
 %files
 %license COPYING LICENSE
 %dir %{_datadir}/%{name}
-%{_lib}/modprobe.d/dist-blacklist.conf
+%{_libdir}/modprobe.d/dist-blacklist.conf
 %{_datadir}/%{name}/*
 
 %changelog
+* Fri May 28 2021 Thomas Crain <thcrain@microsoft.com> - 0.341-4
+- Replace improper %%{_lib} macro usage with %%{_libdir}
+
 * Mon Mar 29 2021 Pawel Winogrodzki <pawelwi@microsoft.com> - 0.341-3
 - Changed source tarball name.
 

--- a/SPECS/hwdata/hwdata.spec
+++ b/SPECS/hwdata/hwdata.spec
@@ -9,7 +9,6 @@ URL:            https://github.com/vcrhonek/hwdata
 #WARNING: the source file downloads as 'v%%{version}.tar.gz' and MUST be re-named to match the 'Source0' tag.
 #Source0:       %%{url}/archive/v%%{version}.tar.gz
 Source0:        %{name}-%{version}.tar.gz
-
 BuildArch:      noarch
 
 %description


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*

- [x] Any updated packages successfully build (or no packages were changed).
- [x] All package sources are available.
- [x] The `%check` section passes for any new packages.
- [x] `./cgmanifest.json` is up-to-date and sorted
- [x] `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md` file is up-to-date and sorted.
- [x] All source files have up-to-date hashes in the `*.signatures.json` files.
- [x] Ready to merge.

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
`hwdata` does not build with Core `dev` branch artifacts, currently.

In Core `1.0-dev`, we can use both the `%{_lib}` macro and the `%{_libdir}` macro to refer to our library directory (`/usr/lib`). In Core `dev`, however, `%{_lib}` was redefined. By using the `%{_libdir}` macro, we can get the `hwdata` package to build using both `1.0-dev` and `dev` artifacts.

[1.0-dev macro declaration](https://github.com/microsoft/CBL-Mariner/blob/1.0-dev/SPECS/mariner-rpm-macros/macros#L9)
[dev macro declaration](https://github.com/microsoft/CBL-Mariner/blob/fe6f1494e50dd13f086b685248125a2703c74274/SPECS/mariner-rpm-macros/macros#L9)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change `%{_lib}` macro in `hwdata` to `%{_libdir}`

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build with latest `dev` branch artifacts
