### PR TITLE
Fixed xwayland-verbosity.patch to patch `ddxProcessArgument`

### DIFF
--- a/SPECS/xorg-x11-server/0026-xwayland-verbosity.patch
+++ b/SPECS/xorg-x11-server/0026-xwayland-verbosity.patch
@@ -1,5 +1,5 @@
 diff --git a/hw/xwayland/xwayland.c b/hw/xwayland/xwayland.c
-index b353167c3..3afaa91a2 100644
+index b353167c3..401770578 100644
 --- a/hw/xwayland/xwayland.c
 +++ b/hw/xwayland/xwayland.c
 @@ -112,8 +112,11 @@ ddxUseMsg(void)
@@ -14,25 +14,25 @@ index b353167c3..3afaa91a2 100644
  int
  ddxProcessArgument(int argc, char *argv[], int i)
  {
-@@ -1151,6 +1154,21 @@ xwl_screen_init(ScreenPtr pScreen, int argc, char **argv)
-         else if (strcmp(argv[i], "-shm") == 0) {
-             xwl_screen->glamor = 0;
-         }
-+        else if (strcmp(argv[i], "-verbose") == 0) {
-+            if (++i < argc && argv[i]) {
-+                char *end;
-+                long val;
+@@ -130,6 +133,21 @@ ddxProcessArgument(int argc, char *argv[], int i)
+     else if (strcmp(argv[i], "-shm") == 0) {
+         return 1;
+     }
++    else if (strcmp(argv[i], "-verbose") == 0) {
++        if (++i < argc && argv[i]) {
++            char *end;
++            long val;
 +
-+                val = strtol(argv[i], &end, 0);
-+                if (*end == '\0') {
-+                    verbosity = val;
-+                    LogSetParameter(XLOG_VERBOSITY, verbosity);
-+                    return 2;
-+                }
++            val = strtol(argv[i], &end, 0);
++            if (*end == '\0') {
++                verbosity = val;
++                LogSetParameter(XLOG_VERBOSITY, verbosity);
++                return 2;
 +            }
-+            LogSetParameter(XLOG_VERBOSITY, ++verbosity);
-+            return 1;
 +        }
-         else if (strcmp(argv[i], "-eglstream") == 0) {
- #ifdef XWL_HAS_EGLSTREAM
-             use_eglstreams = TRUE;
++        LogSetParameter(XLOG_VERBOSITY, ++verbosity);
++        return 1;
++    }
+     else if (strcmp(argv[i], "-eglstream") == 0) {
+         return 1;
+     }

--- a/SPECS/xorg-x11-server/xorg-x11-server.spec
+++ b/SPECS/xorg-x11-server/xorg-x11-server.spec
@@ -21,7 +21,7 @@
 Summary:        X.Org X11 X server
 Name:           xorg-x11-server
 Version:        1.20.10
-Release:        3%{?dist}
+Release:        4%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -385,6 +385,9 @@ find %{buildroot} -type f -name "*.la" -delete -print
 %{_datadir}/aclocal/xorg-server.m4
 
 %changelog
+* Mon Jul 12 2021 Vinicius Jarina <vinja@microsoft.com> - 1.20.10-4
+- Fixed backport to patch ddxProcessArgument https://github.com/mirror/xserver/commit/4341f1da728e4c67187b48865faf06c1312bcdff.
+
 * Wed May 26 2021 Vinicius Jarina <vinja@microsoft.com> - 1.20.10-3
 - Add verbosity backport from https://github.com/mirror/xserver/commit/4341f1da728e4c67187b48865faf06c1312bcdff.
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*

- [x] Any updated packages successfully build (or no packages were changed).
- [x] All package sources are available.
- [x] The `%check` section passes for any new packages.
- [x] `./cgmanifest.json` is up-to-date and sorted
- [x] `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md` file is up-to-date and sorted.
- [x] All source files have up-to-date hashes in the `*.signatures.json` files.
- [x] Ready to merge.

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This PR fixes the patch for Xwayland that was previously sent here: https://github.com/microsoft/CBL-MarinerCoreUI/pull/86
But the code was being patch in the wrong place.

###### Change Log  <!-- REQUIRED -->
@hideyukn88  noticed the verbosity flag wasn't working, after review the patch we noticed the patch wasn't fixing the correct function like here (https://github.com/mirror/xserver/commit/4341f1da728e4c67187b48865faf06c1312bcdff)

So we re-did the patch to fix the correct location

###### Associated issues  <!-- optional -->
https://github.com/microsoft/CBL-MarinerCoreUI/pull/86

###### Links to CVEs  <!-- optional -->

None

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
Local build
