### PR TITLE
[1.0 CoreUI] fix libinput build break

### DIFF
--- a/SPECS/libinput/libinput.spec
+++ b/SPECS/libinput/libinput.spec
@@ -18,9 +18,9 @@ BuildRequires:  meson
 BuildRequires:  pkg-config
 BuildRequires:  python3-devel
 BuildRequires:  pkgconfig(libevdev)
-BuildRequires:  pkgconfig(libudev)
 BuildRequires:  pkgconfig(libwacom)
 BuildRequires:  pkgconfig(mtdev)
+BuildRequires:  systemd-devel
 
 %description
 libinput is a library that handles input devices for display servers and other

--- a/SPECS/libinput/libinput.spec
+++ b/SPECS/libinput/libinput.spec
@@ -3,7 +3,7 @@
 Summary:        Input device library
 Name:           libinput
 Version:        1.16.4
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -100,6 +100,9 @@ find %{buildroot}/%{_mandir}/man1 -type f -regextype posix-egrep -regex "$UTILS_
 %{_mandir}/man1/libinput-test-suite.1*
 
 %changelog
+* Wed Apr 08 2022 Hideyuki Nagase <hideyukn@microsoft.com> - 1.16.4-3
+- Replace pkgconfig(libevdev) with systemd-devel.
+
 * Wed Dec 16 2020 Pawel Winogrodzki <pawelwi@microsoft.com> - 1.16.4-2
 - Initial CBL-Mariner import from Fedora 33 (license: MIT).
 - License verified.


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*

- [ ] Any updated packages successfully build (or no packages were changed).
- [ ] All package sources are available.
- [ ] The `%check` section passes for any new packages.
- [ ] `./cgmanifest.json` is up-to-date and sorted
- [ ] `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md` file is up-to-date and sorted.
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files.
- [ ] Ready to merge.

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
What does the PR accomplish, why was it needed?

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- Issue #xxxx **OR remove this section if N/A**.

###### Links to CVEs  <!-- optional -->

- <https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX> **OR remove this section if N/A**.

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- Local build/Package check on a running image/Something else.
