### PR TITLE
Upgrade libinput to 1.16.5, Patch for CVE-2022-1215

### DIFF
--- a/SPECS/libinput/CVE-2022-1215.patch
+++ b/SPECS/libinput/CVE-2022-1215.patch
@@ -1,0 +1,382 @@
+From e6a4d2407e28cb0b74cfd50f6fbc037d5401e05e Mon Sep 17 00:00:00 2001
+From: Peter Hutterer <peter.hutterer@who-t.net>
+Date: Wed, 30 Mar 2022 09:25:22 +1000
+Subject: [PATCH] evdev: strip the device name of format directives
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This fixes a format string vulnerabilty.
+
+evdev_log_message() composes a format string consisting of a fixed
+prefix (including the rendered device name) and the passed-in format
+buffer. This format string is then passed with the arguments to the
+actual log handler, which usually and eventually ends up being printf.
+
+If the device name contains a printf-style format directive, these ended
+up in the format string and thus get interpreted correctly, e.g. for a
+device "Foo%sBar" the log message vs printf invocation ends up being:
+  evdev_log_message(device, "some message %s", "some argument");
+  printf("event9 - Foo%sBar: some message %s", "some argument");
+
+This can enable an attacker to execute malicious code with the
+privileges of the process using libinput.
+
+To exploit this, an attacker needs to be able to create a kernel device
+with a malicious name, e.g. through /dev/uinput or a Bluetooth device.
+
+To fix this, convert any potential format directives in the device name
+by duplicating percentages.
+
+Pre-rendering the device to avoid the issue altogether would be nicer
+but the current log level hooks do not easily allow for this. The device
+name is the only user-controlled part of the format string.
+
+A second potential issue is the sysname of the device which is also
+sanitized.
+
+This issue was found by Albin Eldstål-Ahrens and Benjamin Svensson from
+Assured AB, and independently by Lukas Lamster.
+
+Fixes #752
+
+Signed-off-by: Peter Hutterer <peter.hutterer@who-t.net>
+---
+ meson.build                        |  1 +
+ src/evdev.c                        | 31 +++++++++++------
+ src/evdev.h                        |  6 ++--
+ src/util-strings.h                 | 55 +++++++++++++++++++++++++++--
+ test/litest-device-format-string.c | 56 ++++++++++++++++++++++++++++++
+ test/litest.h                      |  1 +
+ test/test-utils.c                  | 26 ++++++++++++++
+ 7 files changed, 162 insertions(+), 14 deletions(-)
+ create mode 100644 test/litest-device-format-string.c
+
+diff --git a/meson.build b/meson.build
+index e63749b2..a5d3f77d 100644
+--- a/meson.build
++++ b/meson.build
+@@ -773,6 +773,7 @@ if get_option('tests')
+ 		'test/litest-device-dell-canvas-totem-touch.c',
+ 		'test/litest-device-elantech-touchpad.c',
+ 		'test/litest-device-elan-tablet.c',
++		'test/litest-device-format-string.c',
+ 		'test/litest-device-generic-singletouch.c',
+ 		'test/litest-device-gpio-keys.c',
+ 		'test/litest-device-huion-pentablet.c',
+diff --git a/src/evdev.c b/src/evdev.c
+index 40f0726b..56a7ad54 100644
+--- a/src/evdev.c
++++ b/src/evdev.c
+@@ -2160,19 +2160,19 @@ evdev_device_create(struct libinput_seat *seat,
+ 	struct libinput *libinput = seat->libinput;
+ 	struct evdev_device *device = NULL;
+ 	int rc;
+-	int fd;
++	int fd = -1;
+ 	int unhandled_device = 0;
+ 	const char *devnode = udev_device_get_devnode(udev_device);
+-	const char *sysname = udev_device_get_sysname(udev_device);
++	char *sysname = str_sanitize(udev_device_get_sysname(udev_device));
+ 
+ 	if (!devnode) {
+ 		log_info(libinput, "%s: no device node associated\n", sysname);
+-		return NULL;
++		goto err;
+ 	}
+ 
+ 	if (udev_device_should_be_ignored(udev_device)) {
+ 		log_debug(libinput, "%s: device is ignored\n", sysname);
+-		return NULL;
++		goto err;
+ 	}
+ 
+ 	/* Use non-blocking mode so that we can loop on read on
+@@ -2186,13 +2186,15 @@ evdev_device_create(struct libinput_seat *seat,
+ 			 sysname,
+ 			 devnode,
+ 			 strerror(-fd));
+-		return NULL;
++		goto err;
+ 	}
+ 
+ 	if (!evdev_device_have_same_syspath(udev_device, fd))
+ 		goto err;
+ 
+ 	device = zalloc(sizeof *device);
++	device->sysname = sysname;
++	sysname = NULL;
+ 
+ 	libinput_device_init(&device->base, seat);
+ 	libinput_seat_ref(seat);
+@@ -2215,6 +2217,9 @@ evdev_device_create(struct libinput_seat *seat,
+ 	device->dispatch = NULL;
+ 	device->fd = fd;
+ 	device->devname = libevdev_get_name(device->evdev);
++	/* the log_prefix_name is used as part of a printf format string and
++	 * must not contain % directives, see evdev_log_msg */
++	device->log_prefix_name = str_sanitize(device->devname);
+ 	device->scroll.threshold = 5.0; /* Default may be overridden */
+ 	device->scroll.direction_lock_threshold = 5.0; /* Default may be overridden */
+ 	device->scroll.direction = 0;
+@@ -2255,12 +2260,16 @@ evdev_device_create(struct libinput_seat *seat,
+ 	return device;
+ 
+ err:
+-	close_restricted(libinput, fd);
+-	if (device) {
+-		unhandled_device = device->seat_caps == 0;
+-		evdev_device_destroy(device);
++	if (fd >= 0) {
++		close_restricted(libinput, fd);
++		if (device) {
++			unhandled_device = device->seat_caps == 0;
++			evdev_device_destroy(device);
++		}
+ 	}
+ 
++	free(sysname);
++
+ 	return unhandled_device ? EVDEV_UNHANDLED_DEVICE :  NULL;
+ }
+ 
+@@ -2273,7 +2282,7 @@ evdev_device_get_output(struct evdev_device *device)
+ const char *
+ evdev_device_get_sysname(struct evdev_device *device)
+ {
+-	return udev_device_get_sysname(device->udev_device);
++	return device->sysname;
+ }
+ 
+ const char *
+@@ -2851,6 +2860,8 @@ evdev_device_destroy(struct evdev_device *device)
+ 	if (device->base.group)
+ 		libinput_device_group_unref(device->base.group);
+ 
++	free(device->log_prefix_name);
++	free(device->sysname);
+ 	free(device->output_name);
+ 	filter_destroy(device->pointer.filter);
+ 	libinput_timer_destroy(&device->scroll.timer);
+diff --git a/src/evdev.h b/src/evdev.h
+index b0b1b8c6..785ba9ae 100644
+--- a/src/evdev.h
++++ b/src/evdev.h
+@@ -169,6 +169,8 @@ struct evdev_device {
+ 	struct udev_device *udev_device;
+ 	char *output_name;
+ 	const char *devname;
++	char *log_prefix_name;
++	char *sysname;
+ 	bool was_removed;
+ 	int fd;
+ 	enum evdev_device_seat_capability seat_caps;
+@@ -770,7 +772,7 @@ evdev_log_msg(struct evdev_device *device,
+ 		 sizeof(buf),
+ 		 "%-7s - %s%s%s",
+ 		 evdev_device_get_sysname(device),
+-		 (priority > LIBINPUT_LOG_PRIORITY_DEBUG) ?  device->devname : "",
++		 (priority > LIBINPUT_LOG_PRIORITY_DEBUG) ?  device->log_prefix_name : "",
+ 		 (priority > LIBINPUT_LOG_PRIORITY_DEBUG) ?  ": " : "",
+ 		 format);
+ 
+@@ -805,7 +807,7 @@ evdev_log_msg_ratelimit(struct evdev_device *device,
+ 		 sizeof(buf),
+ 		 "%-7s - %s%s%s",
+ 		 evdev_device_get_sysname(device),
+-		 (priority > LIBINPUT_LOG_PRIORITY_DEBUG) ?  device->devname : "",
++		 (priority > LIBINPUT_LOG_PRIORITY_DEBUG) ?  device->log_prefix_name : "",
+ 		 (priority > LIBINPUT_LOG_PRIORITY_DEBUG) ?  ": " : "",
+ 		 format);
+ 
+diff --git a/src/util-strings.h b/src/util-strings.h
+index 2c31ff80..d6974646 100644
+--- a/src/util-strings.h
++++ b/src/util-strings.h
+@@ -43,8 +43,25 @@
+ #include <xlocale.h>
+ #endif
+ 
+-#define streq(s1, s2) (strcmp((s1), (s2)) == 0)
+-#define strneq(s1, s2, n) (strncmp((s1), (s2), (n)) == 0)
++#include "util-macros.h"
++
++static inline bool
++streq(const char *str1, const char *str2)
++{
++	/* one NULL, one not NULL is always false */
++	if (str1 && str2)
++		return strcmp(str1, str2) == 0;
++	return str1 == str2;
++}
++
++static inline bool
++strneq(const char *str1, const char *str2, int n)
++{
++	/* one NULL, one not NULL is always false */
++	if (str1 && str2)
++		return strncmp(str1, str2, n) == 0;
++	return str1 == str2;
++}
+ 
+ static inline void *
+ zalloc(size_t size)
+@@ -364,3 +381,37 @@ strstartswith(const char *str, const char *prefix)
+ 
+ 	return prefixlen > 0 ? strneq(str, prefix, strlen(prefix)) : false;
+ }
++
++const char *
++safe_basename(const char *filename);
++
++char *
++trunkname(const char *filename);
++
++/**
++ * Return a copy of str with all % converted to %% to make the string
++ * acceptable as printf format.
++ */
++static inline char *
++str_sanitize(const char *str)
++{
++	if (!str)
++		return NULL;
++
++	if (!strchr(str, '%'))
++		return strdup(str);
++
++	size_t slen = min(strlen(str), 512);
++	char *sanitized = zalloc(2 * slen + 1);
++	const char *src = str;
++	char *dst = sanitized;
++
++	for (size_t i = 0; i < slen; i++) {
++		if (*src == '%')
++			*dst++ = '%';
++		*dst++ = *src++;
++	}
++	*dst = '\0';
++
++	return sanitized;
++}
+diff --git a/test/litest-device-format-string.c b/test/litest-device-format-string.c
+new file mode 100644
+index 00000000..aed15db4
+--- /dev/null
++++ b/test/litest-device-format-string.c
+@@ -0,0 +1,56 @@
++
++/*
++ * Copyright © 2013 Red Hat, Inc.
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining a
++ * copy of this software and associated documentation files (the "Software"),
++ * to deal in the Software without restriction, including without limitation
++ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
++ * and/or sell copies of the Software, and to permit persons to whom the
++ * Software is furnished to do so, subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice (including the next
++ * paragraph) shall be included in all copies or substantial portions of the
++ * Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
++ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
++ * DEALINGS IN THE SOFTWARE.
++ */
++
++#include "config.h"
++
++#include "litest.h"
++#include "litest-int.h"
++
++static struct input_id input_id = {
++	.bustype = 0x3,
++	.vendor = 0x0123,
++	.product = 0x0456,
++};
++
++static int events[] = {
++	EV_KEY, BTN_LEFT,
++	EV_KEY, BTN_RIGHT,
++	EV_KEY, BTN_MIDDLE,
++	EV_REL, REL_X,
++	EV_REL, REL_Y,
++	EV_REL, REL_WHEEL,
++	EV_REL, REL_WHEEL_HI_RES,
++	-1 , -1,
++};
++
++TEST_DEVICE("mouse-format-string",
++	.type = LITEST_MOUSE_FORMAT_STRING,
++	.features = LITEST_RELATIVE | LITEST_BUTTON | LITEST_WHEEL,
++	.interface = NULL,
++
++	.name = "Evil %s %d %x Mouse %p %",
++	.id = &input_id,
++	.absinfo = NULL,
++	.events = events,
++)
+diff --git a/test/litest.h b/test/litest.h
+index 08ce20ac..e74065a2 100644
+--- a/test/litest.h
++++ b/test/litest.h
+@@ -307,6 +307,7 @@ enum litest_device_type {
+ 	LITEST_KEYBOARD_LOGITECH_MEDIA_KEYBOARD_ELITE,
+ 	LITEST_SONY_VAIO_KEYS,
+ 	LITEST_SYNAPTICS_PRESSUREPAD,
++	LITEST_MOUSE_FORMAT_STRING,
+ };
+ 
+ #define LITEST_DEVICELESS	-2
+diff --git a/test/test-utils.c b/test/test-utils.c
+index 5faec0e4..bdfa6beb 100644
+--- a/test/test-utils.c
++++ b/test/test-utils.c
+@@ -1150,6 +1150,31 @@ START_TEST(strstartswith_test)
+ }
+ END_TEST
+ 
++START_TEST(strsanitize_test)
++{
++	struct strsanitize_test {
++		const char *string;
++		const char *expected;
++	} tests[] = {
++		{ "foobar", "foobar" },
++		{ "", "" },
++		{ "%", "%%" },
++		{ "%%%%", "%%%%%%%%" },
++		{ "x %s", "x %%s" },
++		{ "x %", "x %%" },
++		{ "%sx", "%%sx" },
++		{ "%s%s", "%%s%%s" },
++		{ NULL, NULL },
++	};
++
++	for (struct strsanitize_test *t = tests; t->string; t++) {
++		char *sanitized = str_sanitize(t->string);
++		ck_assert_str_eq(sanitized, t->expected);
++		free(sanitized);
++	}
++}
++END_TEST
++
+ START_TEST(list_test_insert)
+ {
+ 	struct list_test {
+@@ -1258,6 +1283,7 @@ litest_utils_suite(void)
+ 	tcase_add_test(tc, strstrip_test);
+ 	tcase_add_test(tc, strendswith_test);
+ 	tcase_add_test(tc, strstartswith_test);
++	tcase_add_test(tc, strsanitize_test);
+ 	tcase_add_test(tc, time_conversion);
+ 	tcase_add_test(tc, human_time);
+ 
+-- 
+2.25.1
+

--- a/SPECS/libinput/libinput.signatures.json
+++ b/SPECS/libinput/libinput.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "libinput-1.16.4.tar.xz": "65923a06d5a8970e4a999c4668797b9b689614b62b1d44432ab1c87b65e39e29"
+  "libinput-1.16.5.tar.xz": "42d404af037a0dcc9dee7a1ab0a8e53cec0b62902fc4a262e5be9d2b7452c214"
  }
 }

--- a/SPECS/libinput/libinput.spec
+++ b/SPECS/libinput/libinput.spec
@@ -2,13 +2,14 @@
 
 Summary:        Input device library
 Name:           libinput
-Version:        1.16.4
-Release:        3%{?dist}
+Version:        1.16.5
+Release:        1%{?dist}
 License:        MIT
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 URL:            https://www.freedesktop.org/wiki/Software/libinput/
 Source0:        https://www.freedesktop.org/software/%{name}/%{name}-%{version}.tar.xz
+Patch1:         CVE-2022-1215.patch
 
 BuildRequires:  check
 BuildRequires:  gcc
@@ -49,7 +50,7 @@ The %{name}-test package contains the libinput test suite. It is not
 intended to be run by users.
 
 %prep
-%autosetup
+%autosetup -p1
 
 %build
 %meson -Ddebug-gui=false \
@@ -100,6 +101,9 @@ find %{buildroot}/%{_mandir}/man1 -type f -regextype posix-egrep -regex "$UTILS_
 %{_mandir}/man1/libinput-test-suite.1*
 
 %changelog
+* Wed Aug 31 2022 Jon Slobodzian <joslobo@microsoft.com> - 1.16.5-1
+- Upgrade to 1.16.5-1 and patch CVE-2022-1215
+
 * Wed Apr 06 2022 Hideyuki Nagase <hideyukn@microsoft.com> - 1.16.4-3
 - Replace pkgconfig(libevdev) with systemd-devel.
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -149,8 +149,8 @@
         "type": "other",
         "other": {
           "name": "libinput",
-          "version": "1.16.4",
-          "downloadUrl": "https://www.freedesktop.org/software/libinput/libinput-1.16.4.tar.xz"
+          "version": "1.16.5",
+          "downloadUrl": "https://www.freedesktop.org/software/libinput/libinput-1.16.5.tar.xz"
         }
       }
     },


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
- [x] Any updated packages successfully build (or no packages were changed).
- [x] All package sources are available.
- [x] The `%check` section passes for any new packages.
- [x] `./cgmanifest.json` is up-to-date and sorted
- [x] `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md` file is up-to-date and sorted.
- [x] All source files have up-to-date hashes in the `*.signatures.json` files.
- [x] Ready to merge.

---

###### Summary <!-- REQUIRED -->
What does the PR accomplish, why was it needed?

###### Change Log  <!-- REQUIRED -->
- Change

###### Links to CVEs  <!-- optional -->

- https://nvd.nist.gov/vuln/detail/CVE-2022-1215

###### Test Methodology
